### PR TITLE
Add CRLF file support

### DIFF
--- a/src/dotenv.zig
+++ b/src/dotenv.zig
@@ -163,10 +163,10 @@ pub fn Env(comptime EnvKey: type) type {
                 if (l.len == 0 or l[0] == '#') continue;
 
                 var pair = std.mem.splitScalar(u8, l, '=');
-                const k = std.mem.trim(u8, pair.first(), " \t");
+                const k = std.mem.trim(u8, pair.first(), " \t\r");
 
                 if (pair.next()) |value| {
-                    var value_trimmed = std.mem.trim(u8, value, " \t");
+                    var value_trimmed = std.mem.trim(u8, value, " \t\r");
                     if (value_trimmed.len >= 2) {
                         if (value_trimmed[0] == '"' and value_trimmed[value_trimmed.len - 1] == '"') {
                             value_trimmed = value_trimmed[1 .. value_trimmed.len - 1];


### PR DESCRIPTION
Noticed that on windows, \r - carriage return gets appended to the actual value of the parameter.

for example, if i had .env CRLF file with those contents:
```.env
KEY = value
```

Then, invoking
```zig
env.key(.KEY);
// value\r
```

Which is a bit annoying on windows. This PR is a fix of this issue.